### PR TITLE
Implementing additional mesh types in mesh_construction.pyx

### DIFF
--- a/pyembree/mesh_construction.h
+++ b/pyembree/mesh_construction.h
@@ -11,3 +11,11 @@ int triangulate_hex[12][3] = {
   {0, 3, 7}, {0, 7, 4}, // Face is 0 3 7 4
   {3, 2, 6}, {3, 6, 7}  // Face is 3 2 6 7
 };
+
+// Similarly, this is used to triangulate the tetrahedral cells
+int triangulate_tetra[4][3] = {
+  {0, 1, 2}, 
+  {0, 1, 3},
+  {0, 2, 3},
+  {1, 2, 3}
+};

--- a/pyembree/mesh_construction.h
+++ b/pyembree/mesh_construction.h
@@ -1,0 +1,13 @@
+// This array is used to triangulate the hexahedral mesh elements
+// Each element has six faces with two triangles each.
+// The vertex ordering convention is assumed to follow that used
+// here: http://homepages.cae.wisc.edu/~tautges/papers/cnmev3.pdf
+// Note that this is the case for Exodus II data.
+int triangulate_hex[12][3] = {
+  {0, 1, 2}, {0, 2, 3}, // Face is 0 1 2 3 
+  {4, 5, 6}, {4, 6, 7}, // Face is 4 5 6 7
+  {0, 1, 5}, {0, 5, 4}, // Face is 0 1 5 4
+  {1, 2, 6}, {1, 6, 5}, // Face is 1 2 6 5
+  {0, 3, 7}, {0, 7, 4}, // Face is 0 3 7 4
+  {3, 2, 6}, {3, 6, 7}  // Face is 3 2 6 7
+};

--- a/pyembree/mesh_construction.pyx
+++ b/pyembree/mesh_construction.pyx
@@ -8,42 +8,56 @@ from rtcore cimport Vertex, Triangle, Vec3f
 from libc.stdlib cimport malloc, free
 
 cdef class TriangleMesh:
+    r'''
+
+    This class constructs a polygon mesh with triangular elements and 
+    adds it to the scene. 
+
+    Parameters
+    ----------
+
+    scene : EmbreeScene
+        This is the scene to which the constructed polygons will be
+        added.
+    vertices : a np.ndarray of floats. 
+        This specifies the x, y, and z coordinates of the vertices in 
+        the polygon mesh. This should either have the shape 
+        (num_triangles, 3, 3), or the shape (num_vertices, 3), depending
+        on the value of the `indices` parameter.
+    indices : either None, or a np.ndarray of ints
+        If None, then vertices must have the shape (num_triangles, 3, 3).
+        In this case, `vertices` specifices the coordinates of each
+        vertex of each triangle in the mesh, with vertices being 
+        duplicated if they are shared between triangles. For example,
+        if indices is None, then vertices[2][1][0] should give you 
+        the x-coordinate of the 2nd vertex of the 3rd triangle.
+        If indices is a np.ndarray, then it must have the shape
+        (num_triangles, 3), and `vertices` must have the shape
+        (num_vertices, 3). In this case, indices[2][1] tells you 
+        the index of the 2nd vertex of the 3rd triangle in `indices`,
+        while vertices[5][2] tells you the z-coordinate of the 6th
+        vertex in the mesh. Note that the indexing is assumed to be
+        zero-based. In this setup, vertices can be shared between
+        triangles, and the number of vertices can be less than 3 times
+        the number of triangles.
+            
+    '''
+
     cdef Vertex* vertices
     cdef Triangle* indices
     cdef unsigned int mesh
 
-    def __init__(self, rtcs.EmbreeScene scene, 
-                 np.ndarray vertices, 
+    def __init__(self, rtcs.EmbreeScene scene,
+                 np.ndarray vertices,
                  np.ndarray indices = None):
-        '''
-
-        Constructs a triangular element mesh from a set of vertices and
-        adds them to the scene. There are two different ways of 
-        constructing the mesh:
-        
-        If "indices" is None, then "vertices" should be a num_triangles 
-        by 3 by 3 array of floats, constructed so that (for example) 
-        vertices[2][1][0] gives you the x-component of the 2nd vertex of 
-        the 3rd triangle. In general, vertices may be duplicated when 
-        constructing the mesh in this fashion. 
-        
-        Alternatively, you can also pass in an "indices" array. In that case,
-        "indices" should be a num_triangles by 3 array of ints, and "vertices" 
-        should be a num_vertices by 3 array of floats. These arrays should be 
-        constructed so that indices[2][0] returns the index in "vertices" of 
-        the first vertex of the third triangle, while vertices[4][1] returns
-        the y-coordinate of the 5th vertex. Vertices can be shared when 
-        constructing the mesh in this fashion, so that num_vertices can be 
-        less than 3 times the number of triangles. 
-        
-        '''
 
         if indices is None:
             self._build_from_flat(scene, vertices)
         else:
             self._build_from_indices(scene, vertices, indices)
 
-    cdef void _build_from_flat(self, rtcs.EmbreeScene scene, np.ndarray tri_vertices):
+    cdef void _build_from_flat(self, rtcs.EmbreeScene scene, 
+                               np.ndarray tri_vertices):
         cdef int i, j
         cdef int nt = tri_vertices.shape[0]
         # In this scheme, we don't share any vertices.  This leads to cracks,
@@ -83,30 +97,64 @@ cdef class TriangleMesh:
 
         cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene.scene_i,
                     rtcg.RTC_GEOMETRY_STATIC, nt, nv, 1) 
-        
+
+        # set up vertex and triangle arrays. In this case, we just read
+        # them directly from the inputs
         cdef Vertex* vertices = <Vertex*> rtcg.rtcMapBuffer(scene.scene_i, mesh,
-                        rtcg.RTC_VERTEX_BUFFER)
+                                                    rtcg.RTC_VERTEX_BUFFER)
 
         for i in range(nv):
                 vertices[i].x = tri_vertices[i, 0]
                 vertices[i].y = tri_vertices[i, 1]
                 vertices[i].z = tri_vertices[i, 2]
+
         rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_VERTEX_BUFFER)
 
         cdef Triangle* triangles = <Triangle*> rtcg.rtcMapBuffer(scene.scene_i,
                         mesh, rtcg.RTC_INDEX_BUFFER)
+
         for i in range(nt):
             triangles[i].v0 = tri_indices[i][0]
             triangles[i].v1 = tri_indices[i][1]
             triangles[i].v2 = tri_indices[i][2]
 
         rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_INDEX_BUFFER)
+
         self.vertices = vertices
         self.indices = triangles
         self.mesh = mesh
 
 cdef class ElementMesh(TriangleMesh):
-    # This takes
+    r'''
+
+    Currently, we handle non-triangular mesh types by converting them 
+    to triangular meshes. This class performs this transformation.
+    Currently, this is implemented for hexahedral and tetrahedral
+    meshes.
+
+    Parameters
+    ----------
+
+    scene : EmbreeScene
+        This is the scene to which the constructed polygons will be
+        added.
+    vertices : a np.ndarray of floats. 
+        This specifies the x, y, and z coordinates of the vertices in 
+        the polygon mesh. This should either have the shape 
+        (num_vertices, 3). For example, vertices[2][1] should give the 
+        y-coordinate of the 3rd vertex in the mesh.
+    indices : a np.ndarray of ints
+        This should either have the shape (num_elements, 4) or 
+        (num_elements, 8) for tetrahedral and hexahedral meshes, 
+        respectively. For tetrahedral meshes, each element will 
+        be represented by four triangles in the scene. For hex meshes,
+        each element will be represented by 12 triangles, 2 for each 
+        face. For hex meshes, we assume that the node ordering is as
+        defined here: 
+        http://homepages.cae.wisc.edu/~tautges/papers/cnmev3.pdf
+            
+    '''
+
     def __init__(self, rtcs.EmbreeScene scene,
                  np.ndarray vertices, 
                  np.ndarray indices):

--- a/pyembree/mesh_construction.pyx
+++ b/pyembree/mesh_construction.pyx
@@ -12,7 +12,32 @@ cdef class TriangleMesh:
     cdef Triangle* indices
     cdef unsigned int mesh
 
-    def __init__(self, rtcs.EmbreeScene scene, np.ndarray vertices, np.ndarray indices = None):
+    def __init__(self, rtcs.EmbreeScene scene, 
+                 np.ndarray vertices, 
+                 np.ndarray indices = None):
+        '''
+
+        Constructs a triangular element mesh from a set of vertices and
+        adds them to the scene. There are two different ways of 
+        constructing the mesh:
+        
+        If "indices" is None, then "vertices" should be a num_triangles 
+        by 3 by 3 array of floats, constructed so that (for example) 
+        vertices[2][1][0] gives you the x-component of the 2nd vertex of 
+        the 3rd triangle. In general, vertices may be duplicated when 
+        constructing the mesh in this fashion. 
+        
+        Alternatively, you can also pass in an "indices" array. In that case,
+        "indices" should be a num_triangles by 3 array of ints, and "vertices" 
+        should be a num_vertices by 3 array of floats. These arrays should be 
+        constructed so that indices[2][0] returns the index in "vertices" of 
+        the first vertex of the third triangle, while vertices[4][1] returns
+        the y-coordinate of the 5th vertex. Vertices can be shared when 
+        constructing the mesh in this fashion, so that num_vertices can be 
+        less than 3 times the number of triangles. 
+        
+        '''
+
         if indices is None:
             self._build_from_flat(scene, vertices)
         else:
@@ -52,27 +77,178 @@ cdef class TriangleMesh:
     cdef void _build_from_indices(self, rtcs.EmbreeScene scene,
                                   np.ndarray tri_vertices,
                                   np.ndarray tri_indices):
-        pass
+        cdef int i
+        cdef int nv = tri_vertices.shape[0]
+        cdef int nt = tri_indices.shape[0]
+
+        cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene.scene_i,
+                    rtcg.RTC_GEOMETRY_STATIC, nt, nv, 1) 
+        
+        cdef Vertex* vertices = <Vertex*> rtcg.rtcMapBuffer(scene.scene_i, mesh,
+                        rtcg.RTC_VERTEX_BUFFER)
+
+        for i in range(nv):
+                vertices[i].x = tri_vertices[i, 0]
+                vertices[i].y = tri_vertices[i, 1]
+                vertices[i].z = tri_vertices[i, 2]
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_VERTEX_BUFFER)
+
+        cdef Triangle* triangles = <Triangle*> rtcg.rtcMapBuffer(scene.scene_i,
+                        mesh, rtcg.RTC_INDEX_BUFFER)
+        for i in range(nt):
+            triangles[i].v0 = tri_indices[i][0]
+            triangles[i].v1 = tri_indices[i][1]
+            triangles[i].v2 = tri_indices[i][2]
+
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_INDEX_BUFFER)
+        self.vertices = vertices
+        self.indices = triangles
+        self.mesh = mesh
 
 cdef class ElementMesh(TriangleMesh):
     # This takes
-    def __init__(self, np.ndarray vertices, np.ndarray indices):
-        cdef int nv = vertices.shape[0]
-        cdef int nt = indices.shape[0]
+    def __init__(self, rtcs.EmbreeScene scene,
+                 np.ndarray vertices, 
+                 np.ndarray indices):
         # We need now to figure out if we've been handed quads or tetrahedra.
         # If it's quads, we can build the mesh slightly differently.
         # http://stackoverflow.com/questions/23723993/converting-quadriladerals-in-an-obj-file-into-triangles
         if indices.shape[1] == 8:
-            self._build_from_quads(vertices, indices)
+            self._build_from_quads(scene, vertices, indices)
         elif indices.shape[1] == 4:
-            self._build_from_triangles(vertices, indices)
+            self._build_from_triangles(scene, vertices, indices)
         else:
             raise NotImplementedError
 
-    cdef void _build_from_quads(self, np.ndarray vertices, np.ndarray indices):
+    cdef void _build_from_quads(self, rtcs.EmbreeScene scene,
+                                np.ndarray quad_vertices, 
+                                np.ndarray quad_indices):
+
+        cdef int i, j
+        cdef int nv = quad_vertices.shape[0]
+        cdef int ne = quad_indices.shape[0]
+
         # There are six faces for every quad.  Each of those will be divided
         # into two triangles.
-        pass
+        cdef int nt = 6*2*ne
 
-    cdef void _build_from_triangles(self, np.ndarray vertices, np.ndarray indices):
-        pass
+        cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene.scene_i,
+                    rtcg.RTC_GEOMETRY_STATIC, nt, nv, 1) 
+        
+        cdef Vertex* vertices = <Vertex*> rtcg.rtcMapBuffer(scene.scene_i, mesh,
+                        rtcg.RTC_VERTEX_BUFFER)
+
+        for i in range(nv):
+            vertices[i].x = quad_vertices[i, 0]
+            vertices[i].y = quad_vertices[i, 1]
+            vertices[i].z = quad_vertices[i, 2]
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_VERTEX_BUFFER)
+
+        cdef Triangle* triangles = <Triangle*> rtcg.rtcMapBuffer(scene.scene_i,
+                        mesh, rtcg.RTC_INDEX_BUFFER)
+        for i in range(ne):
+            j = 12*i
+            # go over all the faces here
+            # face is 0 1 2 3
+            # triangles are 0 1 2 and 0 2 3
+            triangles[j].v0 = quad_indices[i][0]
+            triangles[j].v1 = quad_indices[i][1]
+            triangles[j].v2 = quad_indices[i][2]
+            triangles[j+1].v0 = quad_indices[i][0]
+            triangles[j+1].v1 = quad_indices[i][2]
+            triangles[j+1].v2 = quad_indices[i][3]
+            # face is 4 5 6 7
+            # triangles are 4 5 6 and 4 6 7
+            triangles[j+2].v0 = quad_indices[i][4]
+            triangles[j+2].v1 = quad_indices[i][5]
+            triangles[j+2].v2 = quad_indices[i][6]
+            triangles[j+3].v0 = quad_indices[i][4]
+            triangles[j+3].v1 = quad_indices[i][6]
+            triangles[j+3].v2 = quad_indices[i][7]
+            # face is 0 1 5 4
+            # triangles are 0 1 5 and 0 5 4
+            triangles[j+4].v0 = quad_indices[i][0]
+            triangles[j+4].v1 = quad_indices[i][1]
+            triangles[j+4].v2 = quad_indices[i][5]
+            triangles[j+5].v0 = quad_indices[i][0]
+            triangles[j+5].v1 = quad_indices[i][5]
+            triangles[j+5].v2 = quad_indices[i][4]
+            # face is 1 2 6 5
+            # triangles are 1 2 6 and 1 6 5
+            triangles[j+6].v0 = quad_indices[i][1]
+            triangles[j+6].v1 = quad_indices[i][2]
+            triangles[j+6].v2 = quad_indices[i][6]
+            triangles[j+7].v0 = quad_indices[i][1]
+            triangles[j+7].v1 = quad_indices[i][6]
+            triangles[j+7].v2 = quad_indices[i][5]
+            # face is 0 3 7 4
+            # triangles are 0 3 7 and 0 7 4
+            triangles[j+8].v0 = quad_indices[i][0]
+            triangles[j+8].v1 = quad_indices[i][3]
+            triangles[j+8].v2 = quad_indices[i][7]
+            triangles[j+9].v0 = quad_indices[i][0]
+            triangles[j+9].v1 = quad_indices[i][7]
+            triangles[j+9].v2 = quad_indices[i][4]
+            # face is 3 2 6 7
+            # triangles are 3 2 6 and 3 6 7
+            triangles[j+10].v0 = quad_indices[i][3]
+            triangles[j+10].v1 = quad_indices[i][2]
+            triangles[j+10].v2 = quad_indices[i][6]
+            triangles[j+11].v0 = quad_indices[i][3]
+            triangles[j+11].v1 = quad_indices[i][6]
+            triangles[j+11].v2 = quad_indices[i][7]
+
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_INDEX_BUFFER)
+        self.vertices = vertices
+        self.indices = triangles
+        self.mesh = mesh
+
+    cdef void _build_from_triangles(self, rtcs.EmbreeScene scene,
+                                    np.ndarray tetra_vertices, 
+                                    np.ndarray tetra_indices):
+
+        cdef int i, j
+        cdef int nv = tetra_vertices.shape[0]
+        cdef int ne = tetra_indices.shape[0]
+
+        # There are four triangle faces for each tetrahedron.
+        cdef int nt = 4*ne
+
+        cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene.scene_i,
+                    rtcg.RTC_GEOMETRY_STATIC, nt, nv, 1) 
+        
+        cdef Vertex* vertices = <Vertex*> rtcg.rtcMapBuffer(scene.scene_i, mesh,
+                        rtcg.RTC_VERTEX_BUFFER)
+
+        for i in range(nv):
+                vertices[i].x = tetra_vertices[i, 0]
+                vertices[i].y = tetra_vertices[i, 1]
+                vertices[i].z = tetra_vertices[i, 2]
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_VERTEX_BUFFER)
+
+        cdef Triangle* triangles = <Triangle*> rtcg.rtcMapBuffer(scene.scene_i,
+                        mesh, rtcg.RTC_INDEX_BUFFER)
+        for i in range(ne):
+            j = 4*i
+            # the triangles are: 
+            # 0 1 2 
+            # 0 1 3
+            # 0 2 3
+            # 1 2 3
+            triangles[j].v0 = tetra_indices[i][0]
+            triangles[j].v1 = tetra_indices[i][1]
+            triangles[j].v2 = tetra_indices[i][2]
+            triangles[j+1].v0 = tetra_indices[i][0]
+            triangles[j+1].v1 = tetra_indices[i][1]
+            triangles[j+1].v2 = tetra_indices[i][3]
+            triangles[j+2].v0 = tetra_indices[i][0]
+            triangles[j+2].v1 = tetra_indices[i][2]
+            triangles[j+2].v2 = tetra_indices[i][3]
+            triangles[j+3].v0 = tetra_indices[i][1]
+            triangles[j+3].v1 = tetra_indices[i][2]
+            triangles[j+3].v2 = tetra_indices[i][3]
+
+        rtcg.rtcUnmapBuffer(scene.scene_i, mesh, rtcg.RTC_INDEX_BUFFER)
+        self.vertices = vertices
+        self.indices = triangles
+        self.mesh = mesh


### PR DESCRIPTION
This pull request adds support for creating hexahedral and tetrahedral meshes. It also implements creating triangular meshes using an indices array as well as a vertices array.