### PR TITLE
Workaround cython's inability to access .pxd files in zipped egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from Cython.Build import cythonize
 
 include_path = [np.get_include()]
 
-ext_modules = cythonize('pyembree/*.pyx', language='c++', 
+ext_modules = cythonize('pyembree/*.pyx', language='c++',
                         include_dirs=include_path)
 for ext in ext_modules:
     ext.include_dirs = include_path
@@ -16,6 +16,7 @@ for ext in ext_modules:
 setup(
     name="pyembree",
     ext_modules=ext_modules,
+    zip_safe=False,
     packages=find_packages(),
     package_data = {'pyembree': ['*.pxd']}
 )


### PR DESCRIPTION
Cython fails to import pxd files that are in a zipped egg (default action for `setup.py install`). Kudos to @MatthewTurk for figuring it out. 