### PR TITLE
When you install on osx, the library will be a *.dylib, not a *.so. T…

### DIFF
--- a/recipes/embree/build.sh
+++ b/recipes/embree/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd lib
-ln -s libembree.so.* libembree.so
+ln -s libembree.* libembree.so
 cd ..
 cp -rv * "${PREFIX}"


### PR DESCRIPTION
…his fixes the build script to make the correct symlink in both cases. Tested on both my apple laptop and on my Ubuntu workstation.