### PR TITLE
Fixed an attribute in trianges.pyx that prevents compilation

### DIFF
--- a/pyembree/trianges.pyx
+++ b/pyembree/trianges.pyx
@@ -16,7 +16,7 @@ def run_triangles():
     
 cdef unsigned int addCube(rtcs.RTCScene scene_i):
     cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene_i,
-                rtcg.RTCGEOMETRY_STATIC, 12, 8, 1)
+                rtcg.RTC_GEOMETRY_STATIC, 12, 8, 1)
     cdef Vertex* vertices = <Vertex*> rtcg.rtcMapBuffer(scene_i, mesh, rtcg.RTC_VERTEX_BUFFER)
     vertices[0].x = -1
     vertices[0].y = -1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from Cython.Build import cythonize
 include_path = [np.get_include()]
 
 ext_modules = cythonize('pyembree/*.pyx', language='c++',
-                        include_dirs=include_path)
+                        include_path=include_path)
 for ext in ext_modules:
     ext.include_dirs = include_path
     ext.libraries = ["embree"]


### PR DESCRIPTION
I have updated a trianges.pyx since it is using a missing attribute.

I guess one wants `RTC_GEOMETRY_STATIC` instead of `RTCGEOMETRY_STATIC`.

https://github.com/embree/embree/blob/90e49f243703877c7714814d6eaa5aa3422a5839/include/embree2/rtcore_geometry.h#L72

The original error log is presented here

    D:\Embree\pyembree>python setup.py build
    Please put "# distutils: language=c++" in your .pyx or .pxd file(s)
    Compiling pyembree\trianges.pyx because it changed.
    [1/1] Cythonizing pyembree\trianges.pyx

    Error compiling Cython file:
    ------------------------------------------------------------
    ...
    def run_triangles():
        pass

    cdef unsigned int addCube(rtcs.RTCScene scene_i):
        cdef unsigned int mesh = rtcg.rtcNewTriangleMesh(scene_i,
                    rtcg.RTCGEOMETRY_STATIC, 12, 8, 1)
                       ^
    ------------------------------------------------------------

    pyembree\trianges.pyx:19:20: cimported module has no attribute 'RTCGEOMETRY_STATIC'
    Traceback (most recent call last):
      File "setup.py", line 11, in <module>
        include_path=include_path)
      File "C:\Program Files\Python36\lib\site-packages\Cython\Build\Dependencies.py", line 1039, in cythonize
        cythonize_one(*args)
      File "C:\Program Files\Python36\lib\site-packages\Cython\Build\Dependencies.py", line 1161, in cythonize_one
        raise CompileError(None, pyx_file)
    Cython.Compiler.Errors.CompileError: pyembree\trianges.pyx