### PR TITLE
Replace print statements with logging calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,21 @@
+========
+pyembree
+========
+Python Wrapper for Embree
+
+
+Suppressing errors
+------------------
+
+Creating multiple scenes produces some harmless error messages:
+::
+    ERROR CAUGHT IN EMBREE
+    ERROR: Invalid operation
+    ERROR MESSAGE: b'already initialized'
+
+These can be suppressed with:
+
+.. code-block:: python
+
+    import logging
+    logging.getLogger('pyembree').disabled = True

--- a/news/logging.rst
+++ b/news/logging.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Error logging now uses the `logging` module
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyembree/rtcore.pyx
+++ b/pyembree/rtcore.pyx
@@ -1,17 +1,22 @@
+import logging
+
+
+log = logging.getLogger('pyembree')
+
 cdef void print_error(RTCError code):
     if code == RTC_NO_ERROR:
-        print "ERROR: No error"
+        log.error("ERROR: No error")
     elif code == RTC_UNKNOWN_ERROR:
-        print "ERROR: Unknown error"
+        log.error("ERROR: Unknown error")
     elif code == RTC_INVALID_ARGUMENT:
-        print "ERROR: Invalid argument"
+        log.error("ERROR: Invalid argument")
     elif code == RTC_INVALID_OPERATION:
-        print "ERROR: Invalid operation"
+        log.error("ERROR: Invalid operation")
     elif code == RTC_OUT_OF_MEMORY:
-        print "ERROR: Out of memory"
+        log.error("ERROR: Out of memory")
     elif code == RTC_UNSUPPORTED_CPU:
-        print "ERROR: Unsupported CPU"
+        log.error("ERROR: Unsupported CPU")
     elif code == RTC_CANCELLED:
-        print "ERROR: Cancelled"
+        log.error("ERROR: Cancelled")
     else:
         raise RuntimeError

--- a/pyembree/rtcore_scene.pyx
+++ b/pyembree/rtcore_scene.pyx
@@ -1,15 +1,18 @@
 cimport cython
 cimport numpy as np
 import numpy as np
+import logging
 cimport rtcore as rtc
 cimport rtcore_ray as rtcr
 cimport rtcore_geometry as rtcg
 
 
+log = logging.getLogger('pyembree')
+
 cdef void error_printer(const rtc.RTCError code, const char *_str):
-    print "ERROR CAUGHT IN EMBREE"
+    log.error("ERROR CAUGHT IN EMBREE")
     rtc.print_error(code)
-    print "ERROR MESSAGE:", _str
+    log.error("ERROR MESSAGE: %s" % _str)
 
 cdef class EmbreeScene:
 


### PR DESCRIPTION
Fixes #8.

Error messages can then be suppressed with:
```python
import logging
logging.getLogger('pyembree').disabled = True
```