### PR TITLE
Only commit the scene when running.

### DIFF
--- a/news/multi_mesh.rst
+++ b/news/multi_mesh.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+ * Multiple `TriangleMesh` objects can now be added to a scene, and the scene is committed only as-needed.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyembree/mesh_construction.pyx
+++ b/pyembree/mesh_construction.pyx
@@ -59,7 +59,6 @@ cdef class TriangleMesh:
             self._build_from_flat(scene, vertices)
         else:
             self._build_from_indices(scene, vertices, indices)
-        rtcs.rtcCommit(scene.scene_i)
 
     cdef void _build_from_flat(self, rtcs.EmbreeScene scene,
                                np.ndarray tri_vertices):
@@ -172,7 +171,6 @@ cdef class ElementMesh(TriangleMesh):
             self._build_from_tetrahedra(scene, vertices, indices)
         else:
             raise NotImplementedError
-        rtcs.rtcCommit(scene.scene_i)
 
     cdef void _build_from_hexahedra(self, rtcs.EmbreeScene scene,
                                     np.ndarray quad_vertices,

--- a/pyembree/rtcore_scene.pxd
+++ b/pyembree/rtcore_scene.pxd
@@ -63,6 +63,7 @@ cdef extern from "embree2/rtcore_scene.h":
 cdef class EmbreeScene:
     cdef RTCScene scene_i
     # Optional device used if not given, it should be as input of EmbreeScene
+    cdef public int is_committed
     cdef rtc.EmbreeDevice device
 
 cdef enum rayQueryType:

--- a/pyembree/rtcore_scene.pyx
+++ b/pyembree/rtcore_scene.pyx
@@ -31,10 +31,16 @@ cdef class EmbreeScene:
             device = self.device
         rtc.rtcDeviceSetErrorFunction(device.device, error_printer)
         self.scene_i = rtcDeviceNewScene(device.device, RTC_SCENE_STATIC, RTC_INTERSECT1)
+        self.is_committed = 0
 
     def run(self, np.ndarray[np.float32_t, ndim=2] vec_origins,
                   np.ndarray[np.float32_t, ndim=2] vec_directions,
                   dists=None,query='INTERSECT',output=None):
+
+        if self.is_committed == 0:
+            rtcCommit(self.scene_i)
+            self.is_committed = 1
+
         cdef int nv = vec_origins.shape[0]
         cdef int vo_i, vd_i, vd_step
         cdef np.ndarray[np.int32_t, ndim=1] intersect_ids


### PR DESCRIPTION
This enables multiple TriangleMesh objects to be added, and the scene itself will only be committed when the rays are cast.